### PR TITLE
Try exception on retriable ssh

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -527,6 +527,11 @@ useful to ensure that the instance's filesystem is consistent. The system
 will poll the cloud for `shutoff-poll-count` many times, waiting
 `shutoff-poll-interval` seconds between the polls.
 
+`launch-done-stamp` is an optional key to specify a path on the node. The
+node will be considered ready when a file exists at that path. Nodepool will
+retry to check the stamp file `launch-poll-count` many times waiting
+`launch-poll-interval` seconds between the polls.
+
 targets
 -------
 

--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -314,6 +314,13 @@ provider, the Nodepool image types are also defined (see
           diskimage: devstack-trusty
           username: jenkins
           private-key: /home/nodepool/.ssh/id_rsa
+          install: install_node.sh
+          install-done-stamp: /installation_complete
+          install-poll-interval: 10
+          install-poll-count: 60
+          wait-for-shutoff-before-snapshot: False
+          shutoff-poll-count: 0
+          shutoff-poll-interval: 10
     - name: provider2
       username: 'username'
       password: 'password'
@@ -501,6 +508,24 @@ Example::
     values must be 255 characters or less.
 
 .. _targets:
+
+The `install` key is optional and defines a script to be run after Nova
+has reported the node as booted, but before Nodepool considers the node
+ready to be prepared. This script could be used to install the operating
+system.
+
+`install-done-stamp` is also optional - even when `install` is used.  It
+defines a file which will exist when the install phase is complete, and
+will be polled for at the interval (in secs) and count also defined by the
+variables `install-poll-interval` and `install-poll-count`. This allows the
+image to be rebooted by the `install` script - potentially several times
+- before the install phase is completed.
+
+`wait-for-shutoff-before-snapshot` optional parameter to make sure the
+instance has reached `SHUTOFF` state before snapshoting it. This could be
+useful to ensure that the instance's filesystem is consistent. The system
+will poll the cloud for `shutoff-poll-count` many times, waiting
+`shutoff-poll-interval` seconds between the polls.
 
 targets
 -------

--- a/nodepool/nodepool.py
+++ b/nodepool/nodepool.py
@@ -1330,7 +1330,13 @@ class SnapshotImageUpdater(ImageUpdater):
         remaining_polls = self.image.install_poll_count
 
         while remaining_polls:
-            host = self.getSSHConnection(server, key, log, use_password)
+            try:
+                host = self.getSSHConnection(server, key, log, use_password)
+            except Exception as e:
+                self.log.info("Poll %s: Ignored ssh connection error %s",
+                              remaining_polls,
+                              e)
+                host = None
             if host:
                 status = host.ssh(
                     "check install status",

--- a/nodepool/nodepool.py
+++ b/nodepool/nodepool.py
@@ -492,13 +492,18 @@ class NodeLauncher(threading.Thread):
 
         self.node.ip_private = server.get('private_v4')
         self.node.ip = ip
+
+        connect_kwargs = dict(key_filename=self.image.private_key)
+
         self.log.debug("Node id: %s is running, ipv4: %s, ipv6: %s" %
                        (self.node.id, server.get('public_v4'),
                         server.get('public_v6')))
 
-        self.log.debug("Node id: %s testing ssh at ip: %s" %
+        self.waitForLaunchStamp(ip, self.image.username, connect_kwargs)
+
+        self.log.debug("Node id: %s is running, ip: %s, testing ssh" %
                        (self.node.id, ip))
-        connect_kwargs = dict(key_filename=self.image.private_key)
+
         if not utils.ssh_connect(ip, self.image.username,
                                  connect_kwargs=connect_kwargs,
                                  timeout=self.timeout):
@@ -544,6 +549,42 @@ class NodeLauncher(threading.Thread):
             self.log.info("Node id: %s added to jenkins" % self.node.id)
 
         return dt
+
+    def waitForLaunchStamp(self, ip, username, connect_kwargs):
+        if not self.image.launch_done_stamp:
+            self.log.info("No launch condition specified")
+            return
+
+        self.log.info("Node id: %s is ACTIVE, ip: %s, waiting for stamp "
+                "file: %s" % (self.node.id, ip, self.image.launch_done_stamp))
+
+        remaining_polls = self.image.launch_poll_count
+
+        while remaining_polls:
+            try:
+                host = utils.ssh_connect(ip, username, connect_kwargs)
+            except Exception as e:
+                self.log.info("Poll %s: Ignored ssh connection error %s",
+                              remaining_polls,
+                              e)
+                host = None
+
+            if host:
+                status = host.ssh(
+                    "check launch status",
+                    "test -e %s && echo DONE || true" % (
+                        self.image.launch_done_stamp),
+                    output=True)
+                host.close()
+                status = status or ''
+                if "DONE" in status:
+                    self.log.info("Launch stamp found")
+                    return
+            remaining_polls -= 1
+            time.sleep(self.image.launch_poll_interval)
+
+        raise Exception(
+            'Failed to launch host - max number of polls reached')
 
     def createJenkinsNode(self):
         jenkins = self.nodepool.getJenkinsManager(self.target)
@@ -1479,6 +1520,9 @@ class NodePool(threading.Thread):
                     'wait-for-shutoff-before-snapshot', False)
                 i.shutoff_poll_interval = image.get('shutoff-poll-interval', 0)
                 i.shutoff_poll_count = image.get('shutoff-poll-count', 0)
+                i.launch_done_stamp = image.get('launch-done-stamp')
+                i.launch_poll_interval = image.get('launch-poll-interval', 10)
+                i.launch_poll_count = image.get('launch-poll-count', 40)
                 i.diskimage = image.get('diskimage', None)
                 i.username = image.get('username', 'jenkins')
                 i.user_home = image.get('user-home', '/home/jenkins')

--- a/nodepool/nodepool.py
+++ b/nodepool/nodepool.py
@@ -1123,7 +1123,11 @@ class SnapshotImageUpdater(ImageUpdater):
             raise Exception("Unable to find public IP of server")
         server['public_ip'] = ip
 
+        self.installServer(server, key, use_password=use_password)
+
         self.bootstrapServer(server, key, use_password=use_password)
+
+        self.waitForShutOffIfRequested(server_id)
 
         image_id = self.manager.createImage(server_id, hostname,
                                             self.image.meta)
@@ -1159,10 +1163,27 @@ class SnapshotImageUpdater(ImageUpdater):
                                " %s for image id: %s" %
                                (server_id, self.snap_image.id))
 
-    def bootstrapServer(self, server, key, use_password=False):
-        log = logging.getLogger("nodepool.image.build.%s.%s" %
-                                (self.provider.name, self.image.name))
+    def serverIsOff(self, server_id):
+        return self.manager.getServer(server_id)['status'] == 'SHUTOFF'
 
+    def waitForShutOffIfRequested(self, server_id):
+        if not self.image.wait_for_shutoff_before_snapshot:
+            return
+
+        remaining_sleeps = self.image.shutoff_poll_count
+        while remaining_sleeps:
+            if self.serverIsOff(server_id):
+                self.log.debug("Server in SHUTOFF state, no more sleeps")
+                break
+            self.log.debug("%s more sleep(s) to wait for SHUTOFF",
+                           remaining_sleeps)
+            time.sleep(self.image.shutoff_poll_interval)
+            remaining_sleeps -= 1
+
+        if not self.serverIsOff(server_id):
+            raise Exception("Cloud reports, server is still not in SHUTOFF")
+
+    def getSSHConnection(self, server, key, log, use_password):
         ssh_kwargs = dict(log=log)
         if not use_password:
             ssh_kwargs['pkey'] = key
@@ -1190,6 +1211,10 @@ class SnapshotImageUpdater(ImageUpdater):
         if not host:
             raise Exception("Unable to log in via SSH")
 
+        return host
+
+    def copyNodepoolScripts(self, host):
+        host.ssh("make scripts dir", "mkdir -p scripts")
         # /etc/nodepool is world writable because by the time we write
         # the contents after the node is launched, we may not have
         # sudo access any more.
@@ -1206,6 +1231,15 @@ class SnapshotImageUpdater(ImageUpdater):
                      "sudo mv scripts /opt/nodepool-scripts")
             host.ssh("set scripts permissions",
                      "sudo chmod -R a+rx /opt/nodepool-scripts")
+
+    def bootstrapServer(self, server, key, use_password=False):
+        log = logging.getLogger("nodepool.image.build.%s.%s" %
+                                (self.provider.name, self.image.name))
+        host = self.getSSHConnection(server, key, log, use_password)
+        if not host:
+            raise Exception("Unable to log in via SSH")
+
+        self.copyNodepoolScripts(host)
 
         if self.image.setup:
             env_vars = ''
@@ -1224,6 +1258,53 @@ class SnapshotImageUpdater(ImageUpdater):
                      "%s; cd /opt/nodepool-scripts "
                      "&& %s ./%s %s && sync && sleep 5" %
                      (set_path, env_vars, self.image.setup, server['name']))
+
+    def installServer(self, server, key, use_password=False):
+        if not self.image.install:
+            return
+
+        log = logging.getLogger("nodepool.image.install.%s.%s" %
+                                (self.provider.name, self.image.name))
+
+        host = self.getSSHConnection(server, key, log, use_password)
+        if not host:
+            raise Exception("Unable to log in via SSH")
+
+        self.copyNodepoolScripts(host)
+
+        host.ssh("run install script",
+                 "cd /opt/nodepool-scripts && %s ./%s" % (
+                     get_nodepool_env_string(), self.image.install))
+
+        host.close()
+        self.waitForInstallationToCompete(server, key, use_password)
+
+    def waitForInstallationToCompete(self, server, key, use_password):
+        if not self.image.install_done_stamp:
+            return
+
+        log = logging.getLogger("nodepool.image.install.wait.%s.%s" %
+                                (self.provider.name, self.image.name))
+
+        remaining_polls = self.image.install_poll_count
+
+        while remaining_polls:
+            host = self.getSSHConnection(server, key, log, use_password)
+            if host:
+                status = host.ssh(
+                    "check install status",
+                    "test -e %s && echo DONE || true" % (
+                        self.image.install_done_stamp),
+                    output=True)
+                host.close()
+                status = status or ''
+                if "DONE" in status:
+                    return
+            remaining_polls -= 1
+            time.sleep(self.image.install_poll_interval)
+
+        raise Exception(
+            'Failed to install host - max number of polls reached')
 
 
 class ConfigValue(object):
@@ -1389,6 +1470,15 @@ class NodePool(threading.Thread):
                 i.min_ram = image['min-ram']
                 i.name_filter = image.get('name-filter', None)
                 i.setup = image.get('setup', None)
+                i.install = image.get('install')
+                i.install_done_stamp = image.get('install-done-stamp', None)
+                i.install_poll_interval = image.get('install-poll-interval',
+                                                    10)
+                i.install_poll_count = image.get('install-poll-count', 60)
+                i.wait_for_shutoff_before_snapshot = image.get(
+                    'wait-for-shutoff-before-snapshot', False)
+                i.shutoff_poll_interval = image.get('shutoff-poll-interval', 0)
+                i.shutoff_poll_count = image.get('shutoff-poll-count', 0)
                 i.diskimage = image.get('diskimage', None)
                 i.username = image.get('username', 'jenkins')
                 i.user_home = image.get('user-home', '/home/jenkins')
@@ -2672,3 +2762,12 @@ class NodePool(threading.Thread):
         for key in keys:
             statsd.timing(key, dt)
             statsd.incr(key)
+
+
+def get_nodepool_env_string():
+    env_vars = ''
+    for k, v in os.environ.items():
+        if k.startswith('NODEPOOL_'):
+            env_vars += ' %s="%s"' % (k, v)
+
+    return env_vars

--- a/nodepool/nodepool.py
+++ b/nodepool/nodepool.py
@@ -1297,7 +1297,7 @@ class SnapshotImageUpdater(ImageUpdater):
                        "/usr/local/bin:/bin:/usr/bin"
             host.ssh("run setup script",
                      "%s; cd /opt/nodepool-scripts "
-                     "&& %s ./%s %s && sync && sleep 5" %
+                     "&& %s ./%s %s" %
                      (set_path, env_vars, self.image.setup, server['name']))
 
     def installServer(self, server, key, use_password=False):

--- a/nodepool/sshclient.py
+++ b/nodepool/sshclient.py
@@ -66,3 +66,6 @@ class SSHClient(object):
         ftp = self.client.open_sftp()
         ftp.put(source, dest)
         ftp.close()
+
+    def close(self):
+        self.client.close()


### PR DESCRIPTION
The image-building function is unstable now. Sometime the image VM will be deleted before finishing prepare.sh.
The analysis result is as the following:
I think we should add try on this line:
https://github.com/citrix-openstack/nodepool/blob/master/nodepool/nodepool.py#L1333
GitHub
citrix-openstack/nodepool
nodepool - Manage a pool of nodes for a distributed test infrastructure
[3:34] 
sometime it's interrupted by exception:
SSHTimeoutException: Timeout waiting for ssh access
[3:34] 
That's one of the reason for image building failed sometime.
[3:36] 
And it try to ssh to the node just after the reboot; it may also meet the following exception:
SSHException: Error reading SSH protocol banner[Errno 104] Connection reset by peer
[3:37] 
I guess, the installation script exited after trigger reboot. but the ssh goes before reboot take effective. Then it may connects to the VM firstly and then reset by peer.
[3:38] 
Anyway, it should try to catch exceptions.